### PR TITLE
Small improvements

### DIFF
--- a/data/applications.yaml
+++ b/data/applications.yaml
@@ -40,9 +40,9 @@ sources:
 - type: FILE
   attributes:
     paths:
-    - '%%users.homedir%%/AppData/Local/Microsoft/Outlook/*.pab'
-    - '%%users.homedir%%/Documents/Outlook Files/*.pab'
-    separator: '/'
+    - '%%users.localappdata%%\Microsoft\Outlook\*.pab'
+    - '%%users.userprofile%%\Documents\Outlook Files\*.pab'
+    separator: '\'
 labels: [Users, Mail]
 supported_os: [Windows]
 urls: ['http://www.forensicswiki.org/wiki/Personal_Folder_File_(PAB,_PST,_OST)']
@@ -53,9 +53,9 @@ sources:
 - type: FILE
   attributes:
     paths:
-    - '%%users.homedir%%/AppData/Local/Microsoft/Outlook/*.pst'
-    - '%%users.homedir%%/Documents/Outlook Files/*.pst'
-    separator: '/'
+    - '%%users.localappdata%%\Microsoft\Outlook\*.pst'
+    - '%%users.userprofile%%\Documents\Outlook Files\*.pst'
+    separator: '\'
 labels: [Users, Mail]
 supported_os: [Windows]
 urls: ['http://www.forensicswiki.org/wiki/Personal_Folder_File_(PAB,_PST,_OST)']
@@ -66,9 +66,9 @@ sources:
 - type: FILE
   attributes:
     paths:
-    - '%%users.homedir%%/AppData/Local/Microsoft/Outlook/*.ost'
-    - '%%users.homedir%%/Documents/Outlook Files/*.ost'
-    separator: '/'
+    - '%%users.localappdata%%\Microsoft\Outlook\*.ost'
+    - '%%users.userprofile%%\Documents\Outlook Files\*.ost'
+    separator: '\'
 labels: [Users, Mail]
 supported_os: [Windows]
 urls: ['http://www.forensicswiki.org/wiki/Personal_Folder_File_(PAB,_PST,_OST)']

--- a/data/java.yaml
+++ b/data/java.yaml
@@ -13,7 +13,7 @@ sources:
   attributes:
     paths:
     - '%%users.appdata%%\Sun\Java\Deployment\cache\**'
-    - '%%users.userprofile%%\AppData\LocalLow\Sun\Java\Deployment\cache\**'
+    - '%%users.localappdata_low%%\Sun\Java\Deployment\cache\**'
     separator: '\'
   supported_os: [Windows]
 supported_os: [Windows, Linux, Darwin]

--- a/data/webbrowser.yaml
+++ b/data/webbrowser.yaml
@@ -357,6 +357,7 @@ sources:
     - '%%users.localappdata%%\Microsoft\Windows\Temporary Internet Files\Content.IE5\index.dat'
     - '%%users.localappdata%%\Microsoft\Windows\Temporary Internet Files\Low\Content.IE5\index.dat'
     - '%%users.localappdata%%\Microsoft\Windows\WebCache\WebCacheV*.dat'
+    - '%%users.userprofile%%\Local Settings\History\History.IE5\index.dat'
     separator: '\'
 labels: [Browser]
 supported_os: [Windows]

--- a/data/windows.yaml
+++ b/data/windows.yaml
@@ -583,7 +583,7 @@ urls:
 - 'https://www.mandiant.com/blog/fxsst/'
 ---
 name: WindowsCurrentVersion
-doc: The Windows current verson
+doc: The Windows current version
 sources:
 - type: REGISTRY_VALUE
   attributes: {key_value_pairs: [{key: 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion', value: 'CurrentVersion'}]}

--- a/data/windows.yaml
+++ b/data/windows.yaml
@@ -2896,7 +2896,10 @@ name: WindowsTimezone
 doc: The timezone of the system in Olson format.
 sources:
 - type: REGISTRY_VALUE
-  attributes: {key_value_pairs: [{key: 'HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\TimeZoneInformation', value: 'StandardName'}]}
+  attributes:
+    key_value_pairs:
+      - {key: 'HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\TimeZoneInformation', value: 'StandardName'}
+      - {key: 'HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\TimeZoneInformation', value: 'TimeZoneKeyName'}
 provides: [time_zone]
 supported_os: [Windows]
 urls: ['https://github.com/libyal/winreg-kb/blob/master/documentation/Time%20zone%20keys.asciidoc']
@@ -2920,7 +2923,10 @@ name: WindowsUninstallKeys
 doc: Uninstall Registry keys
 sources:
 - type: REGISTRY_KEY
-  attributes: {keys: ['HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Uninstall\*']}
+  attributes:
+      keys:
+      - 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Uninstall\*\*'
+      - 'HKEY_USERS\%%users.sid%%\Software\Microsoft\Windows\CurrentVersion\Uninstall\*\*'
 supported_os: [Windows]
 urls: ['https://msdn.microsoft.com/en-us/library/aa372105(v=vs.85).aspx']
 ---

--- a/data/windows_dll_hijacking.yaml
+++ b/data/windows_dll_hijacking.yaml
@@ -1,3 +1,5 @@
+# DLL Hijack Locations
+
 name: DLLHijackLocations
 doc: DLL search order hijacking locations collected from base Windows 7.
 urls: ['https://www.fireeye.com/blog/threat-research/2010/07/malware-persistence-windows-registry.html']


### PR DESCRIPTION
This pull requests makes some smaller changes:

- Fixes some spelling and documentation
- Uses `%%users.userprofile%%` instead of `homedir` for Windows artifacts consistently
- Improve some artifacts by using `localappdata` instead of hard-coding the path
- Add missing user key for `WindowsUninstallKeys` and also match subkeys for more information about uninstall entries
- Add another timezone key name to `WindowsTimezone`
- Add another location to `InternetExplorerHistory` for older IE versions
by @DeKe42 