### PR TITLE
Also catch /var/log/secure

### DIFF
--- a/linux.yaml
+++ b/linux.yaml
@@ -202,7 +202,7 @@ sources:
   attributes:
     paths:
     - '/var/log/auth.log*'
-    - '/var/log/secure.log*'
+    - '/var/log/secure*'
 labels: [Logs, Authentication]
 supported_os: [Linux]
 ---


### PR DESCRIPTION
Auth logs can also be stored in `/var/log/secure` or `/var/log/secure.YYYYMMDD`, for example on RedHat. Adapt the artifact to catch that.